### PR TITLE
Make renaming spaces a button action

### DIFF
--- a/DynamicVariablePowerTools/Locale/en.json
+++ b/DynamicVariablePowerTools/Locale/en.json
@@ -12,10 +12,18 @@
         "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Button": "Output Component Hierarchy",
         "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Tooltip": "Generates a hierarchical list of all dynamic variable components linked to this space in the <i>Output</i> field.",
 
+        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Name": "Rename Dynamic Variable Spaces",
+        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Description": "Adds a button to dynamic variable spaces for renaming all linked variables.",
+        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Button": "Rename",
+        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Tooltip": "Renames all linked variables.",
+
         "DynamicVariablePowerTools.RenameDynamicVariables.Name": "Rename Dynamic Variables",
         "DynamicVariablePowerTools.RenameDynamicVariables.Description": "Adds a button to dynamic variables for renaming all matching linked variables.",
         "DynamicVariablePowerTools.RenameDynamicVariables.Button": "Rename",
         "DynamicVariablePowerTools.RenameDynamicVariables.Tooltip": "Renames all matching linked variables.",
+
+        "DynamicVariablePowerTools.Config.RenameOptions.Name": "Rename Options",
+        "DynamicVariablePowerTools.Config.RenameOptions.Description": "Options for how dynamic variables should be renamed.",
 
         "DynamicVariablePowerTools.DebugInfo.Name": "Debug Info"
     }

--- a/DynamicVariablePowerTools/RenameButtonHelper.cs
+++ b/DynamicVariablePowerTools/RenameButtonHelper.cs
@@ -1,0 +1,36 @@
+﻿using Elements.Core;
+using FrooxEngine;
+using FrooxEngine.UIX;
+using MonkeyLoader.Resonite;
+using MonkeyLoader.Resonite.UI;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DynamicVariablePowerTools
+{
+    internal static class RenameButtonHelper
+    {
+        internal static void BuildRenameUI(this UIBuilder builder, IField<string> nameField, Action<string> onRename, LocaleString buttonText, LocaleString tooltipText)
+        {
+            var layout = builder.HorizontalLayout(4).Slot.DestroyWhenLocalUserLeaves();
+            builder.PushStyle();
+            var style = builder.Style;
+
+            style.FlexibleWidth = 1;
+            var newNameField = builder.TextField(nameField.Value, parseRTF: false);
+
+            void ChangedListener(object _) => newNameField.Text.Content.Value = nameField.Value;
+            nameField.Changed += ChangedListener;
+            layout.Destroyed += _ => nameField.Changed -= ChangedListener;
+
+            style.FlexibleWidth = -1;
+            style.MinWidth = 256;
+            builder.LocalActionButton(buttonText, button => onRename(newNameField.Text.Content.Value))
+                .WithTooltip(tooltipText);
+
+            builder.PopStyle();
+            builder.NestOut();
+        }
+    }
+}

--- a/DynamicVariablePowerTools/RenameConfig.cs
+++ b/DynamicVariablePowerTools/RenameConfig.cs
@@ -1,0 +1,20 @@
+﻿using MonkeyLoader.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DynamicVariablePowerTools
+{
+    internal sealed class RenameConfig : SingletonConfigSection<RenameConfig>
+    {
+        private static readonly DefiningConfigKey<bool> _changeProtoFluxStringInputs = new("ChangeProtoFluxStringInputs", "Search and rename ProtoFlux inputs with the old name in the form OldName/* (Experimental).", () => false);
+
+        public bool ChangeProtoFluxStringInputs => _changeProtoFluxStringInputs;
+
+        public override string Description => "Rename Options";
+
+        public override string Id => "RenameOptions";
+
+        public override Version Version { get; } = new(1, 0);
+    }
+}


### PR DESCRIPTION
Added a rename button and text field to dynamic variable spaces and removed the implicit renaming behavior.
Made the experimental renaming of ProtoFlux string inputs gated by a configuration option and also apply for renaming dynamic variables.