### PR TITLE
Use replace to change protoflux string inputs

### DIFF
--- a/DynamicVariablePowerTools/DynamicVariablePowerTools.csproj
+++ b/DynamicVariablePowerTools/DynamicVariablePowerTools.csproj
@@ -10,7 +10,7 @@
     <PackageId>DynamicVariablePowerTools</PackageId>
     <Title>Dynamic Variable Power Tools</Title>
     <Authors>Banane9</Authors>
-    <Version>0.1.0-beta</Version>
+    <Version>0.1.1-beta</Version>
     <Description>This MonkeyLoader mod for Resonite adds a variety of powerful functions to dynamic variables and their spaces.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>

--- a/DynamicVariablePowerTools/RenameDirectlyLinkedVariables.cs
+++ b/DynamicVariablePowerTools/RenameDirectlyLinkedVariables.cs
@@ -68,11 +68,12 @@ namespace DynamicVariablePowerTools
             {
                 space.Slot.ForeachComponentInChildren<IInput<string>>(stringInput =>
                 {
+                    // this eats variables like: Space/{0} - so can't construct new name from {newName}/{variableName}
                     DynamicVariableHelper.ParsePath(stringInput.Value, out var spaceName, out var variableName);
                     if (spaceName == null || spaceName != currentName)
                         return;
 
-                    stringInput.Value = $"{newName}/{variableName}";
+                    stringInput.Value = stringInput.Value.Replace(spaceName, newName);
                 }, includeLocal: true, cacheItems: true);
             }
 


### PR DESCRIPTION
Fixes inputs like `Namespace/{0}` having the placeholder eaten