### PR TITLE
Add dynamic variable member actions

### DIFF
--- a/DynamicVariablePowerTools/ContextMenu/DVMA.References.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DVMA.References.cs
@@ -1,0 +1,61 @@
+﻿using FrooxEngine;
+using MonkeyLoader.Resonite;
+
+using GenerationEvent = MonkeyLoader.Resonite.UI.Inspectors.InspectorMemberActionsMenuItemsGenerationEvent;
+
+namespace DynamicVariablePowerTools.ContextMenu
+{
+    internal sealed partial class DynamicVariableMemberActions
+    {
+        private static void CreateSyncRefItems<T>(GenerationEvent eventData)
+            where T : class, IWorldElement
+        {
+            if (eventData.Target is not SyncRef<T> syncRefTarget)
+                return;
+
+            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicReference"), SourceIcon, SourceColor);
+
+            menuItem.Button.LocalPressed += (sender, args) =>
+            {
+                var slot = eventData.Target.FindNearestParent<Slot>();
+                var dynamicReference = slot.AttachComponent<DynamicReference<T>>();
+                dynamicReference.TargetReference.Target = syncRefTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+            if (syncRefTarget.IsLinked)
+                return;
+
+            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+
+            menuItem.Button.LocalPressed += (button, args) =>
+            {
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    var slot = eventData.Target.FindNearestParent<Slot>();
+
+                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                    menuItem2.Button.LocalPressed += (button2, args2) =>
+                    {
+                        syncRefTarget.DriveFromVariable("");
+                        eventData.CloseContextMenu();
+                    };
+
+                    foreach (var option in slot.GetAvailableVariableIdentities<T>())
+                    {
+                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                        menuItem3.Button.LocalPressed += (button2, args2) =>
+                        {
+                            syncRefTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
+                            eventData.CloseContextMenu();
+                        };
+                    }
+                });
+            };
+        }
+    }
+}

--- a/DynamicVariablePowerTools/ContextMenu/DVMA.References.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DVMA.References.cs
@@ -7,55 +7,122 @@ namespace DynamicVariablePowerTools.ContextMenu
 {
     internal sealed partial class DynamicVariableMemberActions
     {
-        private static void CreateSyncRefItems<T>(GenerationEvent eventData)
+        private static ButtonEventHandler GetDriveSyncRefFromVariable<T>(GenerationEvent eventData, SyncRef<T> syncRefTarget, string variable)
             where T : class, IWorldElement
-        {
-            if (eventData.Target is not SyncRef<T> syncRefTarget)
-                return;
-
-            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicReference"), SourceIcon, SourceColor);
-
-            menuItem.Button.LocalPressed += (sender, args) =>
+            => (button, args) =>
             {
-                var slot = eventData.Target.FindNearestParent<Slot>();
-                var dynamicReference = slot.AttachComponent<DynamicReference<T>>();
-                dynamicReference.TargetReference.Target = syncRefTarget;
-
+                syncRefTarget.DriveFromVariable(variable);
                 eventData.CloseContextMenu();
             };
 
-            if (syncRefTarget.IsLinked)
-                return;
-
-            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (button, args) =>
+        private static ButtonEventHandler GetOfferSyncRefDriveActions<T>(GenerationEvent eventData, SyncRef<T> syncRefTarget)
+            where T : class, IWorldElement
+            => (button, args) =>
             {
+                eventData.CloseContextMenu();
+
                 button.Slot.StartTask(async () =>
                 {
                     if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
                         return;
 
-                    var slot = eventData.Target.FindNearestParent<Slot>();
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), DriveIcon, DriveColor)
+                        .Button.LocalPressed += GetDriveSyncRefFromVariable(eventData, syncRefTarget, string.Empty);
 
-                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                    menuItem2.Button.LocalPressed += (button2, args2) =>
+                    foreach (var variable in GetAvailableVariableOptions<T>(eventData.Slot!))
                     {
-                        syncRefTarget.DriveFromVariable("");
-                        eventData.CloseContextMenu();
-                    };
-
-                    foreach (var option in slot.GetAvailableVariableIdentities<T>())
-                    {
-                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                        menuItem3.Button.LocalPressed += (button2, args2) =>
-                        {
-                            syncRefTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
-                            eventData.CloseContextMenu();
-                        };
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromVariable", "variable", variable), DriveIcon, DriveColor)
+                            .Button.LocalPressed += GetDriveSyncRefFromVariable(eventData, syncRefTarget, variable);
                     }
                 });
             };
+
+        private static ButtonEventHandler GetOfferSyncRefReferenceActions<T>(GenerationEvent eventData, SyncRef<T> syncRefTarget)
+            where T : class, IWorldElement
+            => (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference.Blank"), ReferenceIcon, ReferenceColor)
+                        .Button.LocalPressed += GetReferenceSyncRefForVariable(eventData, syncRefTarget, string.Empty);
+
+                    var spaces = eventData.Slot!
+                        .GetAvailableSpaces(SpaceHasName);
+
+                    foreach (var space in spaces)
+                    {
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference.InSpace", "space", space.SpaceName), ReferenceIcon, ReferenceColor)
+                            .Button.LocalPressed += GetReferenceSyncRefForVariable(eventData, syncRefTarget, $"{space.SpaceName}/");
+                    }
+                });
+            };
+
+        private static ButtonEventHandler GetOfferSyncRefSourceActions<T>(GenerationEvent eventData, SyncRef<T> syncRefTarget)
+            where T : class, IWorldElement
+            => (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.Blank"), SourceIcon, SourceColor)
+                        .Button.LocalPressed += GetSourceSyncRefForVariable(eventData, syncRefTarget, string.Empty);
+
+                    var spaces = eventData.Slot!
+                        .GetAvailableSpaces(SpaceHasName);
+
+                    foreach (var space in spaces)
+                    {
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.InSpace", "space", space.SpaceName), SourceIcon, SourceColor)
+                            .Button.LocalPressed += GetSourceSyncRefForVariable(eventData, syncRefTarget, $"{space.SpaceName}/");
+                    }
+                });
+            };
+
+        private static ButtonEventHandler GetReferenceSyncRefForVariable<T>(GenerationEvent eventData, ISyncRef<T> syncRefTarget, string variable)
+            where T : class, IWorldElement
+            => (button, args) =>
+            {
+                var dynamicReference = syncRefTarget.FindNearestParent<Slot>().AttachComponent<DynamicReferenceVariable<ISyncRef<T>>>();
+                dynamicReference.VariableName.Value = variable;
+                dynamicReference.Reference.Target = syncRefTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+        private static ButtonEventHandler GetSourceSyncRefForVariable<T>(GenerationEvent eventData, SyncRef<T> syncRefTarget, string variable)
+            where T : class, IWorldElement
+            => (button, args) =>
+            {
+                syncRefTarget.SyncWithVariable(variable);
+                eventData.CloseContextMenu();
+            };
+
+        private static void OfferSyncRefActions<T>(GenerationEvent eventData)
+            where T : class, IWorldElement
+        {
+            if (eventData.Target is not SyncRef<T> syncRefTarget)
+                return;
+
+            if (!syncRefTarget.IsLinked)
+            {
+                eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive"), DriveIcon, DriveColor)
+                    .Button.LocalPressed += GetOfferSyncRefDriveActions(eventData, syncRefTarget);
+            }
+
+            eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicReference"), SourceIcon, SourceColor)
+                .Button.LocalPressed += GetOfferSyncRefSourceActions(eventData, syncRefTarget);
+
+            eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference"), ReferenceIcon, ReferenceColor)
+                .Button.LocalPressed += GetOfferSyncRefReferenceActions(eventData, syncRefTarget);
         }
     }
 }

--- a/DynamicVariablePowerTools/ContextMenu/DVMA.Types.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DVMA.Types.cs
@@ -1,0 +1,60 @@
+﻿using FrooxEngine;
+using MonkeyLoader.Resonite;
+
+using GenerationEvent = MonkeyLoader.Resonite.UI.Inspectors.InspectorMemberActionsMenuItemsGenerationEvent;
+
+namespace DynamicVariablePowerTools.ContextMenu
+{
+    internal sealed partial class DynamicVariableMemberActions
+    {
+        private static void CreateTypeFieldItems(GenerationEvent eventData)
+        {
+            if (eventData.Target is not SyncType syncTypeTarget)
+                return;
+
+            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicTypeField"), SourceIcon, SourceColor);
+
+            menuItem.Button.LocalPressed += (sender, args) =>
+            {
+                var slot = eventData.Target.FindNearestParent<Slot>();
+                var dynamicReference = slot.AttachComponent<DynamicTypeField>();
+                dynamicReference.TargetField.Target = syncTypeTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+            if (syncTypeTarget.IsLinked)
+                return;
+
+            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+
+            menuItem.Button.LocalPressed += (button, args) =>
+            {
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    var slot = eventData.Target.FindNearestParent<Slot>();
+
+                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                    menuItem2.Button.LocalPressed += (button2, args2) =>
+                    {
+                        syncTypeTarget.DriveFromVariable("");
+                        eventData.CloseContextMenu();
+                    };
+
+                    foreach (var option in slot.GetAvailableVariableIdentities<Type>())
+                    {
+                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                        menuItem3.Button.LocalPressed += (button2, args2) =>
+                        {
+                            syncTypeTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
+                            eventData.CloseContextMenu();
+                        };
+                    }
+                });
+            };
+        }
+    }
+}

--- a/DynamicVariablePowerTools/ContextMenu/DVMA.Types.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DVMA.Types.cs
@@ -7,54 +7,115 @@ namespace DynamicVariablePowerTools.ContextMenu
 {
     internal sealed partial class DynamicVariableMemberActions
     {
-        private static void CreateTypeFieldItems(GenerationEvent eventData)
-        {
-            if (eventData.Target is not SyncType syncTypeTarget)
-                return;
+        private static ButtonEventHandler GetDriveTypeFieldFromVariable(GenerationEvent eventData, SyncType syncTypeTarget, string variable)
+             => (button, args) =>
+             {
+                 syncTypeTarget.DriveFromVariable(variable);
+                 eventData.CloseContextMenu();
+             };
 
-            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicTypeField"), SourceIcon, SourceColor);
-
-            menuItem.Button.LocalPressed += (sender, args) =>
+        private static ButtonEventHandler GetOfferTypeFieldDriveActions(GenerationEvent eventData, SyncType syncTypeTarget)
+            => (button, args) =>
             {
-                var slot = eventData.Target.FindNearestParent<Slot>();
-                var dynamicReference = slot.AttachComponent<DynamicTypeField>();
-                dynamicReference.TargetField.Target = syncTypeTarget;
-
                 eventData.CloseContextMenu();
-            };
 
-            if (syncTypeTarget.IsLinked)
-                return;
-
-            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (button, args) =>
-            {
                 button.Slot.StartTask(async () =>
                 {
                     if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
                         return;
 
-                    var slot = eventData.Target.FindNearestParent<Slot>();
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), DriveIcon, DriveColor)
+                        .Button.LocalPressed += GetDriveTypeFieldFromVariable(eventData, syncTypeTarget, string.Empty);
 
-                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                    menuItem2.Button.LocalPressed += (button2, args2) =>
+                    foreach (var variable in GetAvailableVariableOptions<Type>(eventData.Slot!))
                     {
-                        syncTypeTarget.DriveFromVariable("");
-                        eventData.CloseContextMenu();
-                    };
-
-                    foreach (var option in slot.GetAvailableVariableIdentities<Type>())
-                    {
-                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                        menuItem3.Button.LocalPressed += (button2, args2) =>
-                        {
-                            syncTypeTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
-                            eventData.CloseContextMenu();
-                        };
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromVariable", "variable", variable), DriveIcon, DriveColor)
+                            .Button.LocalPressed += GetDriveTypeFieldFromVariable(eventData, syncTypeTarget, variable);
                     }
                 });
             };
+
+        private static ButtonEventHandler GetOfferTypeFieldReferenceActions(GenerationEvent eventData, SyncType syncTypeTarget)
+            => (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference.Blank"), ReferenceIcon, ReferenceColor)
+                        .Button.LocalPressed += GetReferenceTypeFieldForVariable(eventData, syncTypeTarget, string.Empty);
+
+                    var spaces = eventData.Slot!
+                        .GetAvailableSpaces(SpaceHasName);
+
+                    foreach (var space in spaces)
+                    {
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference.InSpace", "space", space.SpaceName), ReferenceIcon, ReferenceColor)
+                            .Button.LocalPressed += GetReferenceTypeFieldForVariable(eventData, syncTypeTarget, $"{space.SpaceName}/");
+                    }
+                });
+            };
+
+        private static ButtonEventHandler GetOfferTypeFieldSourceActions(GenerationEvent eventData, SyncType syncTypeTarget)
+            => (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.Blank"), SourceIcon, SourceColor)
+                        .Button.LocalPressed += GetSourceTypeFieldForVariable(eventData, syncTypeTarget, string.Empty);
+
+                    var spaces = eventData.Slot!
+                        .GetAvailableSpaces(SpaceHasName);
+
+                    foreach (var space in spaces)
+                    {
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.InSpace", "space", space.SpaceName), SourceIcon, SourceColor)
+                            .Button.LocalPressed += GetSourceTypeFieldForVariable(eventData, syncTypeTarget, $"{space.SpaceName}/");
+                    }
+                });
+            };
+
+        private static ButtonEventHandler GetReferenceTypeFieldForVariable(GenerationEvent eventData, SyncType syncTypeTarget, string variable)
+            => (button, args) =>
+            {
+                var dynamicReference = syncTypeTarget.FindNearestParent<Slot>().AttachComponent<DynamicReferenceVariable<SyncType>>();
+                dynamicReference.VariableName.Value = variable;
+                dynamicReference.Reference.Target = syncTypeTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+        private static ButtonEventHandler GetSourceTypeFieldForVariable(GenerationEvent eventData, SyncType syncTypeTarget, string variable)
+            => (button, args) =>
+            {
+                syncTypeTarget.SyncWithVariable(variable);
+                eventData.CloseContextMenu();
+            };
+
+        private static void OfferTypeFieldActions(GenerationEvent eventData)
+        {
+            if (eventData.Target is not SyncType syncTypeTarget)
+                return;
+
+            if (!syncTypeTarget.IsLinked)
+            {
+                eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive"), DriveIcon, DriveColor)
+                    .Button.LocalPressed += GetOfferTypeFieldDriveActions(eventData, syncTypeTarget);
+            }
+
+            eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicTypeField"), SourceIcon, SourceColor)
+                .Button.LocalPressed += GetOfferTypeFieldSourceActions(eventData, syncTypeTarget);
+
+            eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference"), ReferenceIcon, ReferenceColor)
+                .Button.LocalPressed += GetOfferTypeFieldReferenceActions(eventData, syncTypeTarget);
         }
     }
 }

--- a/DynamicVariablePowerTools/ContextMenu/DVMA.Values.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DVMA.Values.cs
@@ -48,7 +48,7 @@ namespace DynamicVariablePowerTools.ContextMenu
                     eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference.Blank"), ReferenceIcon, ReferenceColor)
                         .Button.LocalPressed += GetReferenceFieldForVariable(eventData, fieldTarget, string.Empty);
 
-                    var spaces = eventData.Target.FindNearestParent<Slot>()
+                    var spaces = eventData.Slot!
                         .GetAvailableSpaces(SpaceHasName);
 
                     foreach (var space in spaces)
@@ -72,7 +72,7 @@ namespace DynamicVariablePowerTools.ContextMenu
                     eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.Blank"), SourceIcon, SourceColor)
                         .Button.LocalPressed += GetSourceFieldForVariable(eventData, fieldTarget, string.Empty);
 
-                    var spaces = eventData.Target.FindNearestParent<Slot>()
+                    var spaces = eventData.Slot!
                         .GetAvailableSpaces(SpaceHasName);
 
                     foreach (var space in spaces)

--- a/DynamicVariablePowerTools/ContextMenu/DVMA.Values.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DVMA.Values.cs
@@ -1,0 +1,121 @@
+﻿using FrooxEngine;
+using MonkeyLoader.Resonite;
+
+using GenerationEvent = MonkeyLoader.Resonite.UI.Inspectors.InspectorMemberActionsMenuItemsGenerationEvent;
+
+namespace DynamicVariablePowerTools.ContextMenu
+{
+    internal sealed partial class DynamicVariableMemberActions
+    {
+        private static ButtonEventHandler GetDriveFieldFromVariable<T>(GenerationEvent eventData, IField<T> fieldTarget, string variable)
+            => (button, args) =>
+            {
+                fieldTarget.DriveFromVariable(variable);
+                eventData.CloseContextMenu();
+            };
+
+        private static ButtonEventHandler GetOfferFieldDriveActions<T>(GenerationEvent eventData, IField<T> fieldTarget)
+            => (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), DriveIcon, DriveColor)
+                        .Button.LocalPressed += GetDriveFieldFromVariable(eventData, fieldTarget, string.Empty);
+
+                    foreach (var variable in GetAvailableVariableOptions<T>(eventData.Slot!))
+                    {
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromVariable", "variable", variable), DriveIcon, DriveColor)
+                            .Button.LocalPressed += GetDriveFieldFromVariable(eventData, fieldTarget, variable);
+                    }
+                });
+            };
+
+        private static ButtonEventHandler GetOfferFieldReferenceActions<T>(GenerationEvent eventData, IField<T> fieldTarget)
+            => (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference.Blank"), ReferenceIcon, ReferenceColor)
+                        .Button.LocalPressed += GetReferenceFieldForVariable(eventData, fieldTarget, string.Empty);
+
+                    var spaces = eventData.Target.FindNearestParent<Slot>()
+                        .GetAvailableSpaces(SpaceHasName);
+
+                    foreach (var space in spaces)
+                    {
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference.InSpace", "space", space.SpaceName), ReferenceIcon, ReferenceColor)
+                            .Button.LocalPressed += GetReferenceFieldForVariable(eventData, fieldTarget, $"{space.SpaceName}/");
+                    }
+                });
+            };
+
+        private static ButtonEventHandler GetOfferFieldSourceActions<T>(GenerationEvent eventData, IField<T> fieldTarget)
+            => (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.Blank"), SourceIcon, SourceColor)
+                        .Button.LocalPressed += GetSourceFieldForVariable(eventData, fieldTarget, string.Empty);
+
+                    var spaces = eventData.Target.FindNearestParent<Slot>()
+                        .GetAvailableSpaces(SpaceHasName);
+
+                    foreach (var space in spaces)
+                    {
+                        eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.InSpace", "space", space.SpaceName), SourceIcon, SourceColor)
+                            .Button.LocalPressed += GetSourceFieldForVariable(eventData, fieldTarget, $"{space.SpaceName}/");
+                    }
+                });
+            };
+
+        private static ButtonEventHandler GetReferenceFieldForVariable<T>(GenerationEvent eventData, IField<T> fieldTarget, string variable)
+            => (button, args) =>
+            {
+                var dynamicReference = fieldTarget.FindNearestParent<Slot>().AttachComponent<DynamicReferenceVariable<IField<T>>>();
+                dynamicReference.VariableName.Value = variable;
+                dynamicReference.Reference.Target = fieldTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+        private static ButtonEventHandler GetSourceFieldForVariable<T>(GenerationEvent eventData, IField<T> fieldTarget, string variable)
+            => (button, args) =>
+            {
+                fieldTarget.SyncWithVariable(variable);
+                eventData.CloseContextMenu();
+            };
+
+        private static void OfferFieldActions<T>(GenerationEvent eventData)
+        {
+            if (eventData.Target is not IField<T> fieldTarget)
+                return;
+
+            if (!fieldTarget.IsLinked)
+            {
+                eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive"), DriveIcon, DriveColor)
+                    .Button.LocalPressed += GetOfferFieldDriveActions(eventData, fieldTarget);
+            }
+
+            eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicField"), SourceIcon, SourceColor)
+                .Button.LocalPressed += GetOfferFieldSourceActions(eventData, fieldTarget);
+
+            eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference"), ReferenceIcon, ReferenceColor)
+                .Button.LocalPressed += GetOfferFieldReferenceActions(eventData, fieldTarget);
+        }
+    }
+}

--- a/DynamicVariablePowerTools/ContextMenu/DynamicVariableMemberActions.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DynamicVariableMemberActions.cs
@@ -1,22 +1,21 @@
 ﻿using FrooxEngine;
-using FrooxEngine.UIX;
 using HarmonyLib;
 using MonkeyLoader;
 using MonkeyLoader.Resonite;
 using MonkeyLoader.Resonite.UI.Inspectors;
 using System.Reflection;
 
-namespace DynamicVariablePowerTools
+namespace DynamicVariablePowerTools.ContextMenu
 {
-    internal sealed class SourceVariableMemberActions
-        : ResoniteAsyncEventHandlerMonkey<SourceVariableMemberActions, InspectorMemberActionsMenuItemsGenerationEvent>
+    internal sealed class DynamicVariableMemberActions
+        : ResoniteAsyncEventHandlerMonkey<DynamicVariableMemberActions, InspectorMemberActionsMenuItemsGenerationEvent>
     {
-        private static readonly MethodInfo _createFieldItemsMethod = AccessTools.DeclaredMethod(typeof(SourceVariableMemberActions), nameof(CreateFieldItems));
-        private static readonly MethodInfo _createSyncRefItemsMethod = AccessTools.DeclaredMethod(typeof(SourceVariableMemberActions), nameof(CreateSyncRefItems));
+        private static readonly MethodInfo _createFieldItemsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateFieldItems));
+        private static readonly MethodInfo _createSyncRefItemsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateSyncRefItems));
 
         private static readonly Dictionary<Type, Action<InspectorMemberActionsMenuItemsGenerationEvent>> _itemCreatorsByType = new()
         {
-            { typeof(Type), AccessTools.MethodDelegate<Action<InspectorMemberActionsMenuItemsGenerationEvent>>(AccessTools.DeclaredMethod(typeof(SourceVariableMemberActions), nameof(CreateTypeFieldItems))) }
+            { typeof(Type), AccessTools.MethodDelegate<Action<InspectorMemberActionsMenuItemsGenerationEvent>>(AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateTypeFieldItems))) }
         };
 
         public override bool CanBeDisabled => true;

--- a/DynamicVariablePowerTools/ContextMenu/DynamicVariableMemberActions.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DynamicVariableMemberActions.cs
@@ -15,11 +15,11 @@ namespace DynamicVariablePowerTools.ContextMenu
     {
         private static readonly Dictionary<Type, Action<GenerationEvent>> _actionOfferersByType = new()
         {
-            { typeof(Type), AccessTools.MethodDelegate<Action<GenerationEvent>>(AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateTypeFieldItems))) }
+            { typeof(Type), AccessTools.MethodDelegate<Action<GenerationEvent>>(AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(OfferTypeFieldActions))) }
         };
 
         private static readonly MethodInfo _offerFieldActionsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(OfferFieldActions));
-        private static readonly MethodInfo _offerSyncRefActionsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateSyncRefItems));
+        private static readonly MethodInfo _offerSyncRefActionsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(OfferSyncRefActions));
 
         public override bool CanBeDisabled => true;
 

--- a/DynamicVariablePowerTools/ContextMenu/DynamicVariableMemberActions.cs
+++ b/DynamicVariablePowerTools/ContextMenu/DynamicVariableMemberActions.cs
@@ -1,51 +1,63 @@
-﻿using FrooxEngine;
+﻿using Elements.Core;
+using FrooxEngine;
 using HarmonyLib;
 using MonkeyLoader;
 using MonkeyLoader.Resonite;
-using MonkeyLoader.Resonite.UI.Inspectors;
+using MonkeyLoader.Resonite.Configuration;
 using System.Reflection;
+
+using GenerationEvent = MonkeyLoader.Resonite.UI.Inspectors.InspectorMemberActionsMenuItemsGenerationEvent;
 
 namespace DynamicVariablePowerTools.ContextMenu
 {
-    internal sealed class DynamicVariableMemberActions
-        : ResoniteAsyncEventHandlerMonkey<DynamicVariableMemberActions, InspectorMemberActionsMenuItemsGenerationEvent>
+    internal sealed partial class DynamicVariableMemberActions
+        : ResoniteAsyncEventHandlerMonkey<DynamicVariableMemberActions, GenerationEvent>
     {
-        private static readonly MethodInfo _createFieldItemsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateFieldItems));
-        private static readonly MethodInfo _createSyncRefItemsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateSyncRefItems));
-
-        private static readonly Dictionary<Type, Action<InspectorMemberActionsMenuItemsGenerationEvent>> _itemCreatorsByType = new()
+        private static readonly Dictionary<Type, Action<GenerationEvent>> _actionOfferersByType = new()
         {
-            { typeof(Type), AccessTools.MethodDelegate<Action<InspectorMemberActionsMenuItemsGenerationEvent>>(AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateTypeFieldItems))) }
+            { typeof(Type), AccessTools.MethodDelegate<Action<GenerationEvent>>(AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateTypeFieldItems))) }
         };
+
+        private static readonly MethodInfo _offerFieldActionsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(OfferFieldActions));
+        private static readonly MethodInfo _offerSyncRefActionsMethod = AccessTools.DeclaredMethod(typeof(DynamicVariableMemberActions), nameof(CreateSyncRefItems));
 
         public override bool CanBeDisabled => true;
 
         public override int Priority => HarmonyLib.Priority.Normal;
 
-        protected override bool AppliesTo(InspectorMemberActionsMenuItemsGenerationEvent eventData)
-            // Check for existence of Slot parent to filter out fields on UserComponents etc.
-            => base.AppliesTo(eventData) && eventData.Target is IField && eventData.Target.FindNearestParent<Slot>() is not null;
+        private static colorX DriveColor => RadiantUI_Constants.Sub.PURPLE;
+        private static Uri DriveIcon => OfficialAssets.Graphics.Icons.ProtoFlux.Drive;
 
-        protected override Task Handle(InspectorMemberActionsMenuItemsGenerationEvent eventData)
+        private static colorX ReferenceColor => RadiantUI_Constants.Neutrals.LIGHT;
+        private static Uri ReferenceIcon => OfficialAssets.Graphics.Icons.ProtoFlux.Reference;
+
+        private static colorX SourceColor => RadiantUI_Constants.Sub.CYAN;
+        private static Uri SourceIcon => OfficialAssets.Graphics.Icons.ProtoFlux.Source;
+
+        protected override bool AppliesTo(GenerationEvent eventData)
+            // Check for existence of Slot to filter out fields on UserComponents etc.
+            => base.AppliesTo(eventData) && eventData.Slot is not null && eventData.Target is IField;
+
+        protected override Task Handle(GenerationEvent eventData)
         {
-            Action<InspectorMemberActionsMenuItemsGenerationEvent>? createItems = null;
+            Action<GenerationEvent>? offerActions;
 
             // Check ISyncRef first because those are IField<RefID>
             if (eventData.Target is ISyncRef syncRef)
             {
-                if (!_itemCreatorsByType.TryGetValue(syncRef.TargetType, out createItems))
+                if (!_actionOfferersByType.TryGetValue(syncRef.TargetType, out offerActions))
                 {
-                    createItems = MakeMethod(_createSyncRefItemsMethod, syncRef.TargetType);
-                    _itemCreatorsByType.Add(syncRef.TargetType, createItems);
+                    offerActions = MakeMethod(_offerSyncRefActionsMethod, syncRef.TargetType);
+                    _actionOfferersByType.Add(syncRef.TargetType, offerActions);
                 }
             }
             // This includes SyncType fields, since they're derived from SyncField<Type> and thus IField<Type>
             else if (eventData.Target is IField field)
             {
-                if (!_itemCreatorsByType.TryGetValue(field.ValueType, out createItems))
+                if (!_actionOfferersByType.TryGetValue(field.ValueType, out offerActions))
                 {
-                    createItems = MakeMethod(_createFieldItemsMethod, field.ValueType);
-                    _itemCreatorsByType.Add(field.ValueType, createItems);
+                    offerActions = MakeMethod(_offerFieldActionsMethod, field.ValueType);
+                    _actionOfferersByType.Add(field.ValueType, offerActions);
                 }
             }
             else
@@ -54,200 +66,31 @@ namespace DynamicVariablePowerTools.ContextMenu
                 return Task.CompletedTask;
             }
 
-            createItems(eventData);
+            offerActions(eventData);
 
             return Task.CompletedTask;
         }
 
-        private static void CreateFieldItems<T>(InspectorMemberActionsMenuItemsGenerationEvent eventData)
+        private static IEnumerable<string> GetAvailableVariableOptions<T>(Slot slot)
         {
-            if (eventData.Target is not IField<T> fieldTarget)
-                return;
-
-            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicField"), OfficialAssets.Graphics.Icons.ProtoFlux.Source, RadiantUI_Constants.Sub.CYAN);
-
-            menuItem.Button.LocalPressed += (button, args) =>
+            foreach (var identity in slot.GetAvailableVariableIdentities<T>())
             {
-                eventData.CloseContextMenu();
+                if (identity.Name.StartsWith(SharedConfig.Identifier))
+                    continue;
 
-                button.Slot.StartTask(async () =>
-                {
-                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
-                        return;
-
-                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.Blank"), (Uri)null!, RadiantUI_Constants.Sub.CYAN);
-
-                    menuItem2.Button.LocalPressed += (button2, args2) =>
-                    {
-                        fieldTarget.SyncWithVariable("");
-                        eventData.CloseContextMenu();
-                    };
-
-                    foreach (var space in eventData.Target.FindNearestParent<Slot>().GetAvailableSpaces())
-                    {
-                        menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.InSpace", "space", space.SpaceName.Value ?? "null"), (Uri)null!, RadiantUI_Constants.Sub.CYAN);
-
-                        menuItem2.Button.LocalPressed += (button2, args2) =>
-                        {
-                            var name = space.SpaceName.Value is null ? "" : $"{space.SpaceName}/";
-                            fieldTarget.SyncWithVariable(name);
-                            eventData.CloseContextMenu();
-                        };
-                    }
-                });
-            };
-
-            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference"), OfficialAssets.Graphics.Icons.ProtoFlux.Reference, RadiantUI_Constants.Neutrals.LIGHT);
-
-            menuItem.Button.LocalPressed += (button, args) =>
-            {
-                var dynamicReference = fieldTarget.FindNearestParent<Slot>().AttachComponent<DynamicReferenceVariable<IField<T>>>();
-                dynamicReference.Reference.Target = fieldTarget;
-
-                eventData.CloseContextMenu();
-            };
-
-            if (fieldTarget.IsLinked)
-                return;
-
-            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive"), OfficialAssets.Graphics.Icons.ProtoFlux.Drive, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (button, args) =>
-            {
-                eventData.CloseContextMenu();
-
-                button.Slot.StartTask(async () =>
-                {
-                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
-                        return;
-
-                    var slot = eventData.Target.FindNearestParent<Slot>();
-
-                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                    menuItem2.Button.LocalPressed += (button2, args2) =>
-                    {
-                        fieldTarget.DriveFromVariable("");
-                        eventData.CloseContextMenu();
-                    };
-
-                    foreach (var option in slot.GetAvailableVariableIdentities<T>())
-                    {
-                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                        menuItem3.Button.LocalPressed += (button2, args2) =>
-                        {
-                            fieldTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
-                            eventData.CloseContextMenu();
-                        };
-                    }
-                });
-            };
+                yield return !string.IsNullOrWhiteSpace(identity.Space.CurrentName)
+                    ? $"{identity.Space.CurrentName}/{identity.Name}"
+                    : identity.Name;
+            }
         }
 
-        private static void CreateSyncRefItems<T>(InspectorMemberActionsMenuItemsGenerationEvent eventData)
-            where T : class, IWorldElement
-        {
-            if (eventData.Target is not SyncRef<T> syncRefTarget)
-                return;
-
-            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicReference"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (sender, args) =>
-            {
-                var slot = eventData.Target.FindNearestParent<Slot>();
-                var dynamicReference = slot.AttachComponent<DynamicReference<T>>();
-                dynamicReference.TargetReference.Target = syncRefTarget;
-
-                eventData.CloseContextMenu();
-            };
-
-            if (syncRefTarget.IsLinked)
-                return;
-
-            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (button, args) =>
-            {
-                button.Slot.StartTask(async () =>
-                {
-                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
-                        return;
-
-                    var slot = eventData.Target.FindNearestParent<Slot>();
-
-                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                    menuItem2.Button.LocalPressed += (button2, args2) =>
-                    {
-                        syncRefTarget.DriveFromVariable("");
-                        eventData.CloseContextMenu();
-                    };
-
-                    foreach (var option in slot.GetAvailableVariableIdentities<T>())
-                    {
-                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                        menuItem3.Button.LocalPressed += (button2, args2) =>
-                        {
-                            syncRefTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
-                            eventData.CloseContextMenu();
-                        };
-                    }
-                });
-            };
-        }
-
-        private static void CreateTypeFieldItems(InspectorMemberActionsMenuItemsGenerationEvent eventData)
-        {
-            if (eventData.Target is not SyncType syncTypeTarget)
-                return;
-
-            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicTypeField"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (sender, args) =>
-            {
-                var slot = eventData.Target.FindNearestParent<Slot>();
-                var dynamicReference = slot.AttachComponent<DynamicTypeField>();
-                dynamicReference.TargetField.Target = syncTypeTarget;
-
-                eventData.CloseContextMenu();
-            };
-
-            if (syncTypeTarget.IsLinked)
-                return;
-
-            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (button, args) =>
-            {
-                button.Slot.StartTask(async () =>
-                {
-                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
-                        return;
-
-                    var slot = eventData.Target.FindNearestParent<Slot>();
-
-                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                    menuItem2.Button.LocalPressed += (button2, args2) =>
-                    {
-                        syncTypeTarget.DriveFromVariable("");
-                        eventData.CloseContextMenu();
-                    };
-
-                    foreach (var option in slot.GetAvailableVariableIdentities<Type>())
-                    {
-                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-                        menuItem3.Button.LocalPressed += (button2, args2) =>
-                        {
-                            syncTypeTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
-                            eventData.CloseContextMenu();
-                        };
-                    }
-                });
-            };
-        }
-
-        private static Action<InspectorMemberActionsMenuItemsGenerationEvent> MakeMethod(MethodInfo method, Type type)
+        private static Action<GenerationEvent> MakeMethod(MethodInfo method, Type type)
         {
             method = method.MakeGenericMethod(type);
-            return AccessTools.MethodDelegate<Action<InspectorMemberActionsMenuItemsGenerationEvent>>(method);
+            return AccessTools.MethodDelegate<Action<GenerationEvent>>(method);
         }
+
+        private static bool SpaceHasName(DynamicVariableSpace space)
+            => !string.IsNullOrEmpty(space.SpaceName.Value);
     }
 }

--- a/DynamicVariablePowerTools/DynamicVariablePowerTools.csproj
+++ b/DynamicVariablePowerTools/DynamicVariablePowerTools.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Remora.Resonite.Sdk/2.1.0">
+﻿<Project Sdk="Remora.Resonite.Sdk/2.0.10">
   <PropertyGroup>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageId>DynamicVariablePowerTools</PackageId>
     <Title>Dynamic Variable Power Tools</Title>
     <Authors>Banane9</Authors>
-    <Version>0.2.0-beta</Version>
+    <Version>0.1.1-beta</Version>
     <Description>This MonkeyLoader mod for Resonite adds a variety of powerful functions to dynamic variables and their spaces.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>

--- a/DynamicVariablePowerTools/DynamicVariablePowerTools.csproj
+++ b/DynamicVariablePowerTools/DynamicVariablePowerTools.csproj
@@ -14,8 +14,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="" />
-    <None Include="Locale\*" Pack="true" PackagePath="content/Locale/" />
+    <None Include="../README.md" Pack="true" PackagePath="" />
+    <None Include="Locale/*" Pack="true" PackagePath="content/Locale/" />
+
+    <Compile Update="ContextMenu/DVMA.*.cs" DependentUpon="ContextMenu/DynamicVariableMemberActions.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DynamicVariablePowerTools/Locale/en.json
+++ b/DynamicVariablePowerTools/Locale/en.json
@@ -1,30 +1,37 @@
 {
-    "localeCode": "en",
-    "authors": [ "Banane9" ],
-    "messages": {
-        "DynamicVariablePowerTools.EnableLinkedVariablesList.Name": "Variable Definitions",
-        "DynamicVariablePowerTools.EnableLinkedVariablesList.Description": "Allow generating a list of all dynamic variable definitions linked to a space.",
-        "DynamicVariablePowerTools.EnableLinkedVariablesList.Button": "Output Variable Definitions",
-        "DynamicVariablePowerTools.EnableLinkedVariablesList.Tooltip": "Generates a list of all dynamic variable definitions linked to this space in the <i>Output</i> field.",
+  "localeCode": "en",
+  "authors": [ "Banane9" ],
+  "messages": {
+    "DynamicVariablePowerTools.EnableLinkedVariablesList.Name": "Variable Definitions",
+    "DynamicVariablePowerTools.EnableLinkedVariablesList.Description": "Allow generating a list of all dynamic variable definitions linked to a space.",
+    "DynamicVariablePowerTools.EnableLinkedVariablesList.Button": "Output Variable Definitions",
+    "DynamicVariablePowerTools.EnableLinkedVariablesList.Tooltip": "Generates a list of all dynamic variable definitions linked to this space in the <i>Output</i> field.",
 
-        "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Name": "Component Hierarchy",
-        "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Description": "Allow generating a hierarchical list of all dynamic variable components linked to a space.",
-        "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Button": "Output Component Hierarchy",
-        "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Tooltip": "Generates a hierarchical list of all dynamic variable components linked to this space in the <i>Output</i> field.",
+    "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Name": "Component Hierarchy",
+    "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Description": "Allow generating a hierarchical list of all dynamic variable components linked to a space.",
+    "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Button": "Output Component Hierarchy",
+    "DynamicVariablePowerTools.EnableLinkedComponentHierarchy.Tooltip": "Generates a hierarchical list of all dynamic variable components linked to this space in the <i>Output</i> field.",
 
-        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Name": "Rename Dynamic Variable Spaces",
-        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Description": "Adds a button to dynamic variable spaces for renaming all linked variables.",
-        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Button": "Rename",
-        "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Tooltip": "Renames all linked variables.",
+    "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Name": "Rename Dynamic Variable Spaces",
+    "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Description": "Adds a button to dynamic variable spaces for renaming all linked variables.",
+    "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Button": "Rename",
+    "DynamicVariablePowerTools.RenameDirectlyLinkedVariables.Tooltip": "Renames all linked variables.",
 
-        "DynamicVariablePowerTools.RenameDynamicVariables.Name": "Rename Dynamic Variables",
-        "DynamicVariablePowerTools.RenameDynamicVariables.Description": "Adds a button to dynamic variables for renaming all matching linked variables.",
-        "DynamicVariablePowerTools.RenameDynamicVariables.Button": "Rename",
-        "DynamicVariablePowerTools.RenameDynamicVariables.Tooltip": "Renames all matching linked variables.",
+    "DynamicVariablePowerTools.RenameDynamicVariables.Name": "Rename Dynamic Variables",
+    "DynamicVariablePowerTools.RenameDynamicVariables.Description": "Adds a button to dynamic variables for renaming all matching linked variables.",
+    "DynamicVariablePowerTools.RenameDynamicVariables.Button": "Rename",
+    "DynamicVariablePowerTools.RenameDynamicVariables.Tooltip": "Renames all matching linked variables.",
 
-        "DynamicVariablePowerTools.Config.RenameOptions.Name": "Rename Options",
-        "DynamicVariablePowerTools.Config.RenameOptions.Description": "Options for how dynamic variables should be renamed.",
+    "DynamicVariablePowerTools.Config.RenameOptions.Name": "Rename Options",
+    "DynamicVariablePowerTools.Config.RenameOptions.Description": "Options for how dynamic variables should be renamed.",
 
-        "DynamicVariablePowerTools.DebugInfo.Name": "Debug Info"
-    }
+    "DynamicVariablePowerTools.DebugInfo.Name": "Debug Info",
+
+    "DynamicVariablePowerTools.Source": "Set up <i>{type}</i>",
+    "DynamicVariablePowerTools.Source.FromBlank": "[Blank]",
+    "DynamicVariablePowerTools.Source.InSpace": "In space <i>{space}</i>",
+    "DynamicVariablePowerTools.Reference": "Set up Reference Variable",
+    "DynamicVariablePowerTools.Drive": "Drive from Dynamic Variable",
+    "DynamicVariablePowerTools.Drive.FromBlank": "[Blank]"
+  }
 }

--- a/DynamicVariablePowerTools/Locale/en.json
+++ b/DynamicVariablePowerTools/Locale/en.json
@@ -27,11 +27,16 @@
 
     "DynamicVariablePowerTools.DebugInfo.Name": "Debug Info",
 
-    "DynamicVariablePowerTools.Source": "Set up <i>{type}</i>",
-    "DynamicVariablePowerTools.Source.FromBlank": "[Blank]",
-    "DynamicVariablePowerTools.Source.InSpace": "In space <i>{space}</i>",
-    "DynamicVariablePowerTools.Reference": "Set up Reference Variable",
     "DynamicVariablePowerTools.Drive": "Drive from Dynamic Variable",
-    "DynamicVariablePowerTools.Drive.FromBlank": "[Blank]"
+    "DynamicVariablePowerTools.Drive.FromBlank": "From [Blank]",
+    "DynamicVariablePowerTools.Drive.FromVariable": "From <i>{variable}</i>",
+
+    "DynamicVariablePowerTools.Source": "Set up <i>{type}</i>",
+    "DynamicVariablePowerTools.Source.Blank": "[Blank]",
+    "DynamicVariablePowerTools.Source.InSpace": "In space <i>{space}</i>",
+
+    "DynamicVariablePowerTools.Reference": "Set up Reference Variable",
+    "DynamicVariablePowerTools.Reference.Blank": "[Blank]",
+    "DynamicVariablePowerTools.Reference.InSpace": "In space <i>{space}</i>"
   }
 }

--- a/DynamicVariablePowerTools/SetupVariableMemberActions.cs
+++ b/DynamicVariablePowerTools/SetupVariableMemberActions.cs
@@ -1,4 +1,5 @@
 ﻿using FrooxEngine;
+using FrooxEngine.UIX;
 using HarmonyLib;
 using MonkeyLoader;
 using MonkeyLoader.Resonite;
@@ -7,22 +8,24 @@ using System.Reflection;
 
 namespace DynamicVariablePowerTools
 {
-    internal sealed class SetupVariableMemberActions
-        : ResoniteAsyncEventHandlerMonkey<SetupVariableMemberActions, InspectorMemberActionsMenuItemsGenerationEvent>
+    internal sealed class SourceVariableMemberActions
+        : ResoniteAsyncEventHandlerMonkey<SourceVariableMemberActions, InspectorMemberActionsMenuItemsGenerationEvent>
     {
-        private static readonly MethodInfo _createFieldItemsMethod = AccessTools.DeclaredMethod(typeof(SetupVariableMemberActions), nameof(CreateFieldItems));
-        private static readonly MethodInfo _createSyncRefItemsMethod = AccessTools.DeclaredMethod(typeof(SetupVariableMemberActions), nameof(CreateSyncRefItems));
+        private static readonly MethodInfo _createFieldItemsMethod = AccessTools.DeclaredMethod(typeof(SourceVariableMemberActions), nameof(CreateFieldItems));
+        private static readonly MethodInfo _createSyncRefItemsMethod = AccessTools.DeclaredMethod(typeof(SourceVariableMemberActions), nameof(CreateSyncRefItems));
 
         private static readonly Dictionary<Type, Action<InspectorMemberActionsMenuItemsGenerationEvent>> _itemCreatorsByType = new()
         {
-            { typeof(Type), AccessTools.MethodDelegate<Action<InspectorMemberActionsMenuItemsGenerationEvent>>(AccessTools.DeclaredMethod(typeof(SetupVariableMemberActions), nameof(CreateTypeFieldItems))) }
+            { typeof(Type), AccessTools.MethodDelegate<Action<InspectorMemberActionsMenuItemsGenerationEvent>>(AccessTools.DeclaredMethod(typeof(SourceVariableMemberActions), nameof(CreateTypeFieldItems))) }
         };
 
         public override bool CanBeDisabled => true;
+
         public override int Priority => HarmonyLib.Priority.Normal;
 
         protected override bool AppliesTo(InspectorMemberActionsMenuItemsGenerationEvent eventData)
-            => base.AppliesTo(eventData) && eventData.Target is IField;
+            // Check for existence of Slot parent to filter out fields on UserComponents etc.
+            => base.AppliesTo(eventData) && eventData.Target is IField && eventData.Target.FindNearestParent<Slot>() is not null;
 
         protected override Task Handle(InspectorMemberActionsMenuItemsGenerationEvent eventData)
         {
@@ -37,6 +40,7 @@ namespace DynamicVariablePowerTools
                     _itemCreatorsByType.Add(syncRef.TargetType, createItems);
                 }
             }
+            // This includes SyncType fields, since they're derived from SyncField<Type> and thus IField<Type>
             else if (eventData.Target is IField field)
             {
                 if (!_itemCreatorsByType.TryGetValue(field.ValueType, out createItems))
@@ -58,50 +62,82 @@ namespace DynamicVariablePowerTools
 
         private static void CreateFieldItems<T>(InspectorMemberActionsMenuItemsGenerationEvent eventData)
         {
-            var menuItem = eventData.ContextMenu.AddItem("Set up DynamicField", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+            if (eventData.Target is not IField<T> fieldTarget)
+                return;
+
+            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicField"), OfficialAssets.Graphics.Icons.ProtoFlux.Source, RadiantUI_Constants.Sub.CYAN);
 
             menuItem.Button.LocalPressed += (button, args) =>
             {
-                // Swap to eventData.Worker when updated
-                var slot = eventData.Target.FindNearestParent<Slot>();
-                var dynamicField = slot.AttachComponent<DynamicField<T>>();
-                dynamicField.TargetField.Target = (IField<T>)eventData.Target;
-
-                button.World.LocalUser.CloseContextMenu(eventData.Summoner);
-            };
-
-            menuItem = eventData.ContextMenu.AddItem("Drive from Dynamic Variable", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
-
-            menuItem.Button.LocalPressed += (button, args) =>
-            {
-                button.World.LocalUser.CloseContextMenu(eventData.Summoner);
+                eventData.CloseContextMenu();
 
                 button.Slot.StartTask(async () =>
                 {
-                    await button.World.LocalUser.OpenContextMenu(eventData.Summoner, args.source.Slot);
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
 
-                    // Need to check dynamic variable spaces hiding eachother
-                    // Also use full space/varName for drive
-                    var slot = eventData.Target.FindNearestParent<Slot>();
-                    var options = slot.GetComponentsInParents<DynamicVariableSpace>()
-                        .SelectMany(space => space._dynamicValues.Keys.Where(variable => typeof(T).IsAssignableFrom(variable.type)))
-                        .ToArray();
+                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.Blank"), (Uri)null!, RadiantUI_Constants.Sub.CYAN);
 
-                    var menuItem2 = eventData.ContextMenu.AddItem("Blank", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
                     menuItem2.Button.LocalPressed += (button2, args2) =>
                     {
-                        var driver = slot.AttachComponent<DynamicValueVariableDriver<T>>();
-                        driver.Target.Target = (IField<T>)eventData.Target;
-                        button.World.LocalUser.CloseContextMenu(eventData.Summoner);
+                        fieldTarget.SyncWithVariable("");
+                        eventData.CloseContextMenu();
                     };
 
-                    foreach (var option in options)
+                    foreach (var space in eventData.Target.FindNearestParent<Slot>().GetAvailableSpaces())
                     {
-                        var menuItem3 = eventData.ContextMenu.AddItem(option.name, (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                        menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source.InSpace", "space", space.SpaceName.Value ?? "null"), (Uri)null!, RadiantUI_Constants.Sub.CYAN);
+
+                        menuItem2.Button.LocalPressed += (button2, args2) =>
+                        {
+                            var name = space.SpaceName.Value is null ? "" : $"{space.SpaceName}/";
+                            fieldTarget.SyncWithVariable(name);
+                            eventData.CloseContextMenu();
+                        };
+                    }
+                });
+            };
+
+            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Reference"), OfficialAssets.Graphics.Icons.ProtoFlux.Reference, RadiantUI_Constants.Neutrals.LIGHT);
+
+            menuItem.Button.LocalPressed += (button, args) =>
+            {
+                var dynamicReference = fieldTarget.FindNearestParent<Slot>().AttachComponent<DynamicReferenceVariable<IField<T>>>();
+                dynamicReference.Reference.Target = fieldTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+            if (fieldTarget.IsLinked)
+                return;
+
+            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive"), OfficialAssets.Graphics.Icons.ProtoFlux.Drive, RadiantUI_Constants.Sub.PURPLE);
+
+            menuItem.Button.LocalPressed += (button, args) =>
+            {
+                eventData.CloseContextMenu();
+
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    var slot = eventData.Target.FindNearestParent<Slot>();
+
+                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                    menuItem2.Button.LocalPressed += (button2, args2) =>
+                    {
+                        fieldTarget.DriveFromVariable("");
+                        eventData.CloseContextMenu();
+                    };
+
+                    foreach (var option in slot.GetAvailableVariableIdentities<T>())
+                    {
+                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
                         menuItem3.Button.LocalPressed += (button2, args2) =>
                         {
-                            ((IField<T>)eventData.Target).DriveFromVariable(option.name);
-                            button.World.LocalUser.CloseContextMenu(eventData.Summoner);
+                            fieldTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
+                            eventData.CloseContextMenu();
                         };
                     }
                 });
@@ -114,14 +150,48 @@ namespace DynamicVariablePowerTools
             if (eventData.Target is not SyncRef<T> syncRefTarget)
                 return;
 
-            var menuItem = eventData.ContextMenu.AddItem("Set up DynamicReference", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicReference"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
 
             menuItem.Button.LocalPressed += (sender, args) =>
             {
-                // Swap to eventData.Worker when updated
                 var slot = eventData.Target.FindNearestParent<Slot>();
                 var dynamicReference = slot.AttachComponent<DynamicReference<T>>();
                 dynamicReference.TargetReference.Target = syncRefTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+            if (syncRefTarget.IsLinked)
+                return;
+
+            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+
+            menuItem.Button.LocalPressed += (button, args) =>
+            {
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    var slot = eventData.Target.FindNearestParent<Slot>();
+
+                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                    menuItem2.Button.LocalPressed += (button2, args2) =>
+                    {
+                        syncRefTarget.DriveFromVariable("");
+                        eventData.CloseContextMenu();
+                    };
+
+                    foreach (var option in slot.GetAvailableVariableIdentities<T>())
+                    {
+                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                        menuItem3.Button.LocalPressed += (button2, args2) =>
+                        {
+                            syncRefTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
+                            eventData.CloseContextMenu();
+                        };
+                    }
+                });
             };
         }
 
@@ -130,14 +200,48 @@ namespace DynamicVariablePowerTools
             if (eventData.Target is not SyncType syncTypeTarget)
                 return;
 
-            var menuItem = eventData.ContextMenu.AddItem("Set up DynamicTypeField", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+            var menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Source", "type", "DynamicTypeField"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
 
             menuItem.Button.LocalPressed += (sender, args) =>
             {
-                // Swap to eventData.Worker when updated
                 var slot = eventData.Target.FindNearestParent<Slot>();
                 var dynamicReference = slot.AttachComponent<DynamicTypeField>();
                 dynamicReference.TargetField.Target = syncTypeTarget;
+
+                eventData.CloseContextMenu();
+            };
+
+            if (syncTypeTarget.IsLinked)
+                return;
+
+            menuItem = eventData.ContextMenu.AddItem(Mod.GetLocaleString("DriveFrom"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+
+            menuItem.Button.LocalPressed += (button, args) =>
+            {
+                button.Slot.StartTask(async () =>
+                {
+                    if (await eventData.OpenContextMenuAsync(args.source.Slot) is null)
+                        return;
+
+                    var slot = eventData.Target.FindNearestParent<Slot>();
+
+                    var menuItem2 = eventData.ContextMenu.AddItem(Mod.GetLocaleString("Drive.FromBlank"), (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                    menuItem2.Button.LocalPressed += (button2, args2) =>
+                    {
+                        syncTypeTarget.DriveFromVariable("");
+                        eventData.CloseContextMenu();
+                    };
+
+                    foreach (var option in slot.GetAvailableVariableIdentities<Type>())
+                    {
+                        var menuItem3 = eventData.ContextMenu.AddItem($"{option.Space.SpaceName}/{option.Name}", (Uri)null!, RadiantUI_Constants.Sub.PURPLE);
+                        menuItem3.Button.LocalPressed += (button2, args2) =>
+                        {
+                            syncTypeTarget.DriveFromVariable($"{option.Space.SpaceName}/{option.Name}");
+                            eventData.CloseContextMenu();
+                        };
+                    }
+                });
             };
         }
 


### PR DESCRIPTION
They allow creating drivers from existing variables available on the field's parent slot, as well as setting up a DynamicField / DynamicReference pointing to it, or even a DynamicReferenceVariable referencing the field itself